### PR TITLE
fix スマホで若干縮小される問題解消

### DIFF
--- a/backend/resources/views/layouts/OLDmain.blade.php
+++ b/backend/resources/views/layouts/OLDmain.blade.php
@@ -63,12 +63,12 @@
 
     </header>
    
-    <main>
+    <div>
 
         @yield('content')
         
         
-    </main>
+    </div>
     <footer>
      <p class="text-center">{{"@"}}usuyuki2021</p>
     </footer>

--- a/backend/resources/views/layouts/main.blade.php
+++ b/backend/resources/views/layouts/main.blade.php
@@ -110,12 +110,12 @@
         </div>
     </header>
    
-    <main>
+    <div>
 
         @yield('content')
         
         
-    </main>
+    </div>
     @component('components.footer')
     @endcomponent
     <div class="sm:hidden" style="height: 60px" >

--- a/backend/resources/views/layouts/noLogIn.blade.php
+++ b/backend/resources/views/layouts/noLogIn.blade.php
@@ -72,12 +72,12 @@
       
     </header>
    
-    <main>
+    <div>
 
         @yield('content')
         
         
-    </main>
+    </div>
     @component('components.footer')
     @endcomponent
     


### PR DESCRIPTION
mainタグが原因だった、widthを100%でも100vwでも最大サイズにならず、divにするだけで全て治った

スマホの見た目が若干変だったのが、これで解決
