### PR TITLE
fix スマホ画面ズレ修正

### DIFF
--- a/backend/resources/views/layouts/main.blade.php
+++ b/backend/resources/views/layouts/main.blade.php
@@ -121,7 +121,7 @@
 
 
 
-            <div class="flex items-center justify-center mr-4">
+            <div class="flex items-center justify-center">
                 <p class="sm:block hidden kiwi-maru">{{ Auth::user()->name }}</p>
                 <p class="sm:hidden block ml-4 mt-2"><a href="{{url("/settings")}}"><span
                             class="material-icons">settings</span></a></p>


### PR DESCRIPTION
ずっと未解決な問題

**設定アイコンのマージンが原因**