### PR TITLE
feat 管理者ページにユーザー情報表示追加

### DIFF
--- a/backend/app/Http/Controllers/admin/HomeAdminController.php
+++ b/backend/app/Http/Controllers/admin/HomeAdminController.php
@@ -3,13 +3,31 @@
 namespace App\Http\Controllers\admin;
 
 use App\Http\Controllers\Controller;
-
+use App\Models\Diary;
+use App\Models\Statistic;
+use App\Models\Statistic_per_month;
+use App\Models\User;
 
 class HomeAdminController extends Controller
 {
     public function __invoke()
     {
-        return view('admin/homeAdmin');
+        $users=User::get();
+        foreach($users as $user){
+            $statistic="";//怖いので初期化
+            //日記数統計から取ってきていないのは統計データーがそもそも無いが、日記はある可能性があるため
+            $user->diary_count=Diary::where("user_id",$user->id)->count() ?? 0;
+            $user->latest_diary=Diary::where("user_id",$user->id)->first(['date'])->date ?? 'なし';
+            $user->oldest_diary=Diary::where("user_id",$user->id)->orderBy("date","asc")->first(['date'])->date ?? 'なし';
+            $user->statistics_per_month_count=Statistic_per_month::where("user_id",$user->id)->count() ?? 0;
+            $user->diary_average="未測定";//無い可能性もあるので0に
+            $statistic=Statistic::where("user_id",$user->id)->first(['total_words','total_diaries']);
+            if(!empty($statistic)){
+                $user->diary_average=$statistic->total_words/$statistic->total_diaries;
+            }
+        }
+
+        return view('admin/homeAdmin',['users' => $users]);
     }
 
 }

--- a/backend/app/Http/Controllers/admin/HomeAdminController.php
+++ b/backend/app/Http/Controllers/admin/HomeAdminController.php
@@ -21,9 +21,14 @@ class HomeAdminController extends Controller
             $user->oldest_diary=Diary::where("user_id",$user->id)->orderBy("date","asc")->first(['date'])->date ?? 'なし';
             $user->statistics_per_month_count=Statistic_per_month::where("user_id",$user->id)->count() ?? 0;
             $user->diary_average="未測定";//無い可能性もあるので0に
-            $statistic=Statistic::where("user_id",$user->id)->first(['total_words','total_diaries']);
+            $statistic=Statistic::where("user_id",$user->id)->first(['statistic_progress','total_words','total_diaries']);
             if(!empty($statistic)){
-                $user->diary_average=$statistic->total_words/$statistic->total_diaries;
+                //統計あっても生成中の可能性があるので
+                if($statistic->statistic_progress==100){
+                    $user->diary_average=round($statistic->total_words/$statistic->total_diaries);
+                }else{
+                    $user->diary_average="生成中";//無い可能性もあるので0に
+                }
             }
         }
 

--- a/backend/resources/views/admin/homeAdmin.blade.php
+++ b/backend/resources/views/admin/homeAdmin.blade.php
@@ -15,6 +15,89 @@
         <p class="text-center my-12 mx-4 text-3xl"><a href="{{url("/administrator/role_rank")}}">ロールとランク</a></p>
     </div>
     <div class="statistic-content">
+        {{-- 表示 --}}
+        <div class="overflow-x-auto">
+            <table class="nlp-normal-table mx-auto" border="1">
+                <tr>
+                    <th>id</th>
+                    <th>日記数</th>
+                    <th>統計数(月別)</th>
+                    <th>日記平均文字数</th>
+                    <th>アカウント作成日</th>
+                    <th>アカウント更新日</th>
+                    <th>メール認証日</th>
+                    <th>最新の日記日</th>
+                    <th>最古の日記日</th>
+                    <th>user_rank_id</th>
+                    <th>user_role_id</th>
+                    <th>appearance_id</th>
+                    <th>is_showed_update_user_rank</th>
+                    <th>is_showed_update_system_info</th>
+                    <th>is_showed_service_info</th>
+                </tr>
+
+                @include('components.statisticHeading',['icon'=>'category','title'=>'ユーザー情報'])
+
+                {{-- 登録済みデータ表示 --}}
+                @isset($users)
+
+                @foreach($users as $user)
+                <tr>
+                    <td>
+                        {{$user->id}}
+                    </td>
+                    <td>
+                        {{$user->diary_count}}
+                    </td>
+                    <td>
+                        {{$user->statistics_per_month_count}}
+                    </td>
+                    <td>
+                        {{$user->diary_average}}
+                    </td>
+                    <td>
+                        {{$user->created_at}}
+                    </td>
+                    <td>
+                        {{$user->updated_at}}
+                    </td>
+                    <td>
+                        {{$user->email_verified_at}}
+                    </td>
+                    <td>
+                        {{$user->latest_diary}}
+                    </td>
+                    <td>
+                        {{$user->oldest_diary}}
+                    </td>
+                    <td>
+                        {{$user->user_rank_id}}
+                    </td>
+                    <td>
+                        {{$user->user_role_id}}
+                    </td>
+                    <td>
+                        {{$user->appearance_id}}
+                    </td>
+                    <td>
+                        {{$user->is_showed_update_user_rank}}
+                    </td>
+                    <td>
+                        {{$user->is_showed_update_system_info}}
+                    </td>
+                    <td>
+                        {{$user->is_showed_service_info}}
+                    </td>
+
+
+                </tr>
+                @endforeach
+                @endisset
+            </table>
+        </div>
+
+    </div>
+    <div class="statistic-content">
         @include('components.statisticHeading',['icon'=>'category','title'=>'php情報'])
 
         <?php //phpinfo(); ?>

--- a/backend/resources/views/components/basis/header.blade.php
+++ b/backend/resources/views/components/basis/header.blade.php
@@ -61,7 +61,7 @@
         <p><a href="{{url("/statistics/home")}}">統計</a></p>
         <p><a href="{{url("/statistics/settings")}}">統計設定</a></p>
         <p><a href="{{url("/settings")}}">設定</a></p>
-        <p><a href="{{url("/security")}}">セキュリティ</a></p>
+        /* <p><a href="{{url("/security")}}">セキュリティ</a></p> */
         @if( Auth::user()->user_role_id==2)
         <p><a href="{{url("/administrator")}}">管理者</a></p>
         @endif


### PR DESCRIPTION
# やったこと
<img width="1335" alt="image" src="https://user-images.githubusercontent.com/63891531/151696533-c49787f5-930a-49c4-b764-6941ea90872c.png">

セキュリティページタブの廃止