### PR TITLE
fix グローバルスコープ外れていない

### DIFF
--- a/backend/app/Http/Controllers/admin/HomeAdminController.php
+++ b/backend/app/Http/Controllers/admin/HomeAdminController.php
@@ -16,12 +16,12 @@ class HomeAdminController extends Controller
         foreach($users as $user){
             $statistic="";//怖いので初期化
             //日記数統計から取ってきていないのは統計データーがそもそも無いが、日記はある可能性があるため
-            $user->diary_count=Diary::where("user_id",$user->id)->count() ?? 0;
-            $user->latest_diary=Diary::where("user_id",$user->id)->first(['date'])->date ?? 'なし';
-            $user->oldest_diary=Diary::where("user_id",$user->id)->orderBy("date","asc")->first(['date'])->date ?? 'なし';
-            $user->statistics_per_month_count=Statistic_per_month::where("user_id",$user->id)->count() ?? 0;
+            $user->diary_count=Diary::withoutGlobalScopes()->where("user_id",$user->id)->count() ?? 0;
+            $user->latest_diary=Diary::withoutGlobalScopes()->where("user_id",$user->id)->first(['date'])->date ?? 'なし';
+            $user->oldest_diary=Diary::withoutGlobalScopes()->where("user_id",$user->id)->orderBy("date","asc")->first(['date'])->date ?? 'なし';
+            $user->statistics_per_month_count=Statistic_per_month::withoutGlobalScopes()->where("user_id",$user->id)->count() ?? 0;
             $user->diary_average="未測定";//無い可能性もあるので0に
-            $statistic=Statistic::where("user_id",$user->id)->first(['statistic_progress','total_words','total_diaries']);
+            $statistic=Statistic::withoutGlobalScopes()->where("user_id",$user->id)->first(['statistic_progress','total_words','total_diaries']);
             if(!empty($statistic)){
                 //統計あっても生成中の可能性があるので
                 if($statistic->statistic_progress==100){


### PR DESCRIPTION
# やったこと

さっきのPRでグローバルスコープ外れていない結果、ログイン中のユーザー情報しか見えない状態

→一分の情報はグローバルスコープ適用外なので見れてしまったため気づかなかった