### PR TITLE
fix 最新の日記が最新じゃないときがある(本番環境はそう)

### DIFF
--- a/backend/app/Http/Controllers/admin/HomeAdminController.php
+++ b/backend/app/Http/Controllers/admin/HomeAdminController.php
@@ -17,7 +17,7 @@ class HomeAdminController extends Controller
             $statistic="";//怖いので初期化
             //日記数統計から取ってきていないのは統計データーがそもそも無いが、日記はある可能性があるため
             $user->diary_count=Diary::withoutGlobalScopes()->where("user_id",$user->id)->count() ?? 0;
-            $user->latest_diary=Diary::withoutGlobalScopes()->where("user_id",$user->id)->first(['date'])->date ?? 'なし';
+            $user->latest_diary=Diary::withoutGlobalScopes()->where("user_id",$user->id)->orderBy("date","desc")->first(['date'])->date ?? 'なし';
             $user->oldest_diary=Diary::withoutGlobalScopes()->where("user_id",$user->id)->orderBy("date","asc")->first(['date'])->date ?? 'なし';
             $user->statistics_per_month_count=Statistic_per_month::withoutGlobalScopes()->where("user_id",$user->id)->count() ?? 0;
             $user->diary_average="未測定";//無い可能性もあるので0に


### PR DESCRIPTION
さっきのPRと同じ
最新日記が最新じゃないとき
DBのソートしなくても最初に引っ張られるのが最新とは限らない
