### PR TITLE
feat 日記表示ページの変更

### DIFF
--- a/backend/_ide_helper_models.php
+++ b/backend/_ide_helper_models.php
@@ -60,7 +60,7 @@ namespace App\Models{
  * @property int|null $statistic_progress 生成状況(生成まで時間かかるので)
  * @property string|null $title タイトル
  * @property string $content 本文
- * @property string $date 日記の日付
+ * @property \Illuminate\Support\Carbon $date 日記の日付
  * @property mixed|null $sentence 一文ごとの位置(係り受けで使う)
  * @property mixed|null $chunk 係り受け構造
  * @property mixed|null $token 形態素分析された中身を格納 品詞(POS)、原形(lemma)などが存在

--- a/backend/app/Http/Controllers/diary/EditDiaryController.php
+++ b/backend/app/Http/Controllers/diary/EditDiaryController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\diary;
 
 use App\Http\Controllers\Controller;
 use App\Models\Diary;
+use App\UseCases\Diary\ShapeContentWithNlp;
 use App\UseCases\Diary\ShapeStatisticFromDiaries;
 use Illuminate\Support\Carbon;
 use Illuminate\Http\Request;
@@ -14,7 +15,8 @@ use Illuminate\Support\Str;
 class EditDiaryController extends Controller
 {
     public function __construct(
-        private ShapeStatisticFromDiaries $shapeStatisticFromDiaries
+        private ShapeStatisticFromDiaries $shapeStatisticFromDiaries,
+        private ShapeContentWithNlp $shapeContentWithNlp,
     ) {
     }
     /**
@@ -39,6 +41,7 @@ class EditDiaryController extends Controller
 
         //undefined防止
         $resembleDiaries = [];
+        $contentWithNlp = [];
 
         //最新の情報のときのみ
         if ($diary->statistic_progress == 100 && $stati_update->gt($diary_update)) {
@@ -50,6 +53,8 @@ class EditDiaryController extends Controller
             $diary->important_words = array_values(json_decode($diary->important_words, true));
             $diary->special_people = array_values(json_decode($diary->special_people, true));
 
+            /** NLP付き表示を生成する */
+            $contentWithNlp = $this->shapeContentWithNlp->invoke($diary);
 
             /**
              * modelでの型定義とwhere("hoge->fuga")でjsonの中身引っ張ってこれる
@@ -68,7 +73,7 @@ class EditDiaryController extends Controller
             }
         }
 
-        return view('diary/edit', ['diary' => $diary, 'previous' => $previous, 'next' => $next, 'resembleDiaries' => $resembleDiaries,]);
+        return view('diary/edit', ['diary' => $diary, 'contentWithNlp' => $contentWithNlp, 'previous' => $previous, 'next' => $next, 'resembleDiaries' => $resembleDiaries,]);
     }
 
     public function newPage()

--- a/backend/app/Http/Controllers/diary/HomeDiaryController.php
+++ b/backend/app/Http/Controllers/diary/HomeDiaryController.php
@@ -8,6 +8,7 @@ use App\Models\Osirase;
 use App\Models\Releasenote;
 use App\Models\User_rank;
 use App\UseCases\Diary\ShapeStatisticFromDiaries;
+use DateTime;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 
@@ -108,6 +109,8 @@ class homeDiaryController extends Controller
         $i = 0;
         foreach ($oldDiaries as $diary) {
             if ($diary['date'] != "no") {
+                $oldDiariesDate = new DateTime($oldDiaries[$i]["date"]);
+                $oldDiaries[$i]["date"] = $oldDiariesDate->format("Y年n月j日");
                 $oldDiaries[$i]["is_latest_statistic"] = false;
                 //統計データがあり、その統計データが日記の内容と合致しているかの判断
                 if (isset($oldDiaries[$i]["updated_statistic_at"])) {

--- a/backend/app/Models/Diary.php
+++ b/backend/app/Models/Diary.php
@@ -55,7 +55,10 @@ class Diary extends Model
     protected $attributes = [
         "statistic_progress" => 0,
     ];
-
-    //日付設定
-    protected $dates = ['user_rank_updated_at'];
+    /**
+     * 日付の登録(format使えるように)
+     *
+     * @var array
+     */
+    protected $dates = ['date', 'created_at', 'updated_at'];
 }

--- a/backend/app/UseCases/Diary/ShapeContentWithNlp.php
+++ b/backend/app/UseCases/Diary/ShapeContentWithNlp.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\UseCases\Diary;
+
+use App\Models\Diary;
+
+/**
+ * 日記の本文をNLPで彩るようの配列に変換するユースケース
+ *
+ */
+class ShapeContentWithNlp
+{
+    /**
+     * @return array<{form:string,xPOSTag:string,color:string}>
+     */
+    public function invoke(Diary $diary): array
+    {
+        $wordBox = [];
+        $token2Json = json_decode($diary->token);
+        foreach ($token2Json as $token) {
+            /**
+             * @memo uPosTagが世界共通の大別で、xPosがローカルの分類(名詞-固有名詞など)
+             */
+            switch ($token->uPOSTag) {
+                case 'NOUN': //名詞
+                    $color = "#ffffff";
+                    break;
+                case 'VERB': //動詞
+                    $color = "#e3e5e8";
+                    break;
+                default:
+                    $color = "#f9fff9";
+                    break;
+            }
+            $wordBox[] = [
+                'form' => $token->form,
+                'xPOSTag' => $token->xPOSTag,
+                'color' => $color,
+            ];
+        }
+        return $wordBox;
+    }
+}

--- a/backend/app/UseCases/Diary/ShapeStatisticFromDiaries.php
+++ b/backend/app/UseCases/Diary/ShapeStatisticFromDiaries.php
@@ -1,16 +1,18 @@
 <?php
+
 namespace App\UseCases\Diary;
 
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
+/**
+ * アーカイブなどで日記の統計情報を表示するための前処理
+ * 最新かの判定、jsonの変換など
+ *
+ */
 class ShapeStatisticFromDiaries
 {
-    /**
-     * アーカイブなどで日記の統計情報を表示するための前処理
-     * 最新かの判定、jsonの変換など
-     *
-     */
+
     public function invoke(Collection $diaries): Collection
     {
         /**

--- a/backend/public/css/kadodeMain.css
+++ b/backend/public/css/kadodeMain.css
@@ -43,6 +43,7 @@ body {
 .main-wrapper {
     max-width: min(90vw, 1600px);
     margin: 0 auto;
+    padding-top: 30px;
     min-height: 100vh;
 }
 @media screen and (max-width: 640px) {

--- a/backend/public/css/kadodeMain.css
+++ b/backend/public/css/kadodeMain.css
@@ -61,6 +61,7 @@ body {
     --status-poor: #e2534a;
     --status-good: #339c76;
     --status-excellent: #33769c;
+    --submit-bubble-color: #f9fff9;
     /* ヘッダー高さ */
     --header-height: 73px;
     /* メディアクエリ */
@@ -190,6 +191,149 @@ input[type="submit"] {
     border-radius: 0 0 4px 4px;
     padding: 0.25em 0.5em;
 }
+/* 日記保存ボタンここから */
+#submitDiary {
+    background-color: inherit;
+    border: 1px solid var(--button-main-color);
+    transition: background-color 0.3s, box-shadow 0.3s, color 0.3s;
+    box-shadow: inset 0 0 0 rgba(75, 137, 150, 0.4),
+        0 0 0.5em rgba(75, 137, 150, 0.6);
+    color: var(--text-main-color);
+
+    position: relative;
+    z-index: 1;
+    /* ↑こいつが鍵を握っている */
+}
+#submitDiary:hover {
+    border: 3px solid var(--button-main-color);
+    box-shadow: inset 0 0 0 rgba(75, 137, 150, 0.4),
+        0 0 1.5em rgba(75, 137, 150, 0.6);
+}
+/*
+    送信時のボタンをかっこよくする
+    https://codepen.io/nourabusoud/pen/ypZzMM
+
+    Copyright (c) 2022 by Nour Saud (https://codepen.io/nourabusoud/pen/ypZzMM)
+    Released under the MIT license
+    http://opensource.org/licenses/mit-license.php
+*/
+#submitDiary:before,
+#submitDiary:after {
+    position: absolute;
+    content: "";
+    display: block;
+    width: 140%;
+    height: 100%;
+    left: -20%;
+    transition: all ease-in-out 0.5s;
+    background-repeat: no-repeat;
+}
+
+#submitDiary:before {
+    display: none;
+    top: -75%;
+    background-image: radial-gradient(
+            circle,
+            var(--submit-bubble-color) 20%,
+            transparent 20%
+        ),
+        radial-gradient(
+            circle,
+            transparent 20%,
+            var(--submit-bubble-color) 20%,
+            transparent 30%
+        ),
+        radial-gradient(circle, var(--submit-bubble-color) 20%, transparent 20%),
+        radial-gradient(circle, var(--submit-bubble-color) 20%, transparent 20%),
+        radial-gradient(
+            circle,
+            transparent 10%,
+            var(--submit-bubble-color) 15%,
+            transparent 20%
+        ),
+        radial-gradient(circle, var(--submit-bubble-color) 20%, transparent 20%),
+        radial-gradient(circle, var(--submit-bubble-color) 20%, transparent 20%),
+        radial-gradient(circle, var(--submit-bubble-color) 20%, transparent 20%),
+        radial-gradient(circle, var(--submit-bubble-color) 20%, transparent 20%);
+    background-size: 22px 22px, 20px 20px, 15px 15px, 20px 20px, 18px 18px,
+        22px 22px, 15px 15px, 22px 22px, 18px 18px;
+}
+
+#submitDiary:after {
+    display: none;
+    bottom: -75%;
+    background-image: radial-gradient(
+            circle,
+            var(--submit-bubble-color) 20%,
+            transparent 20%
+        ),
+        radial-gradient(circle, var(--submit-bubble-color) 20%, transparent 20%),
+        radial-gradient(
+            circle,
+            transparent 10%,
+            var(--submit-bubble-color) 15%,
+            transparent 20%
+        ),
+        radial-gradient(circle, var(--submit-bubble-color) 20%, transparent 20%),
+        radial-gradient(circle, var(--submit-bubble-color) 20%, transparent 20%),
+        radial-gradient(circle, var(--submit-bubble-color) 20%, transparent 20%),
+        radial-gradient(circle, var(--submit-bubble-color) 20%, transparent 20%);
+    background-size: 15px 15px, 20px 20px, 18px 18px, 20px 20px, 15px 15px,
+        10px 10px, 20px 20px;
+}
+
+#submitDiary:active {
+    transform: scale(0.9);
+    background-color: var(--button-main-color);
+    box-shadow: 0 2px 25px rgba(75, 137, 150, 0.2);
+}
+
+#submitDiary.animate:before {
+    display: block;
+    animation: topBubbles ease-in-out 0.45s forwards;
+}
+
+#submitDiary.animate:after {
+    display: block;
+    animation: bottomBubbles ease-in-out 0.45s forwards;
+}
+
+@keyframes topBubbles {
+    0% {
+        background-position: 5% 90%, 10% 90%, 10% 90%, 15% 90%, 25% 90%, 25% 90%,
+            40% 90%, 55% 90%, 70% 90%;
+    }
+
+    50% {
+        background-position: 0% 80%, 0% 20%, 10% 40%, 20% 0%, 30% 30%, 22% 50%,
+            50% 50%, 65% 20%, 90% 30%;
+    }
+
+    100% {
+        background-position: 0% 70%, 0% 10%, 10% 30%, 20% -10%, 30% 20%, 22% 40%,
+            50% 40%, 65% 10%, 90% 20%;
+        background-size: 0% 0%, 0% 0%, 0% 0%, 0% 0%, 0% 0%, 0% 0%;
+    }
+}
+
+@keyframes bottomBubbles {
+    0% {
+        background-position: 10% -10%, 30% 10%, 55% -10%, 70% -10%, 85% -10%,
+            70% -10%, 70% 0%;
+    }
+
+    50% {
+        background-position: 0% 80%, 20% 80%, 45% 60%, 60% 100%, 75% 70%,
+            95% 60%, 105% 0%;
+    }
+
+    100% {
+        background-position: 0% 90%, 20% 90%, 45% 70%, 60% 110%, 75% 80%,
+            95% 70%, 110% 10%;
+        background-size: 0% 0%, 0% 0%, 0% 0%, 0% 0%, 0% 0%, 0% 0%;
+    }
+}
+/* 日記保存ボタンここまで */
 input[type="text"],
 input[type="password"],
 input[type="email"] {
@@ -332,7 +476,7 @@ li ol {
     display: flex;
     justify-content: center;
     flex-wrap: wrap;
-    margin: 3em auto;
+    margin: 0 auto 3em;
 }
 .diary-main > div {
     width: 50%;
@@ -832,4 +976,66 @@ td {
 }
 #kadodeCatchphrase span:nth-of-type(3) {
     transform: translateX(20px) translateY(15px) rotate(20deg);
+}
+
+/* 日記編集ページ */
+.dateWrapper {
+    max-width: 1120px;
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin: 3em auto;
+}
+.diaryContentWrapper {
+    margin: 0 auto 4em;
+    padding: 0 0.5em;
+    width: 600px;
+    font-size: 18px;
+}
+@media screen and (max-width: 640px) {
+    .diaryContentWrapper {
+        width: 90%;
+    }
+}
+
+/* 日記編集ページのタブ */
+.tab_item {
+    width: calc(100% / 3);
+    height: 50px;
+    border-bottom: 3px solid var(--button-main-color);
+    font-size: 16px;
+    text-align: center;
+    display: block;
+    line-height: 50px;
+    float: left;
+    text-align: center;
+    transition: all 0.2s ease;
+    color: var(--text-main-color);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.tab_item:hover {
+    opacity: 0.75;
+}
+
+input[name="tab_item"] {
+    display: none;
+}
+.tab_content {
+    display: none;
+    padding-top: 70px;
+    min-height: 80vh;
+}
+
+#editDiary:checked ~ #editDiaryContent,
+#viewDiary:checked ~ #viewDiaryContent,
+#viewStatistic:checked ~ #viewStatisticContent {
+    display: block;
+}
+
+.board-main input:checked + .tab_item {
+    background-color: var(--button-main-color);
+    color: var(--text-main-color);
 }

--- a/backend/public/js/kadodeMain.js
+++ b/backend/public/js/kadodeMain.js
@@ -45,6 +45,13 @@ if (document.getElementById("diary-content") != null) {
     });
 }
 
+function diaryContentChange() {
+    window.addEventListener("beforeunload", function (event) {
+        event.preventDefault();
+        event.returnValue = "";
+    });
+}
+
 //ヘッダー時計用桁数調整
 // function set2fig(num) {
 //     // 桁数が1桁だったら先頭に0を加えて2桁に調整する

--- a/backend/public/js/kadodeMain.js
+++ b/backend/public/js/kadodeMain.js
@@ -45,13 +45,44 @@ if (document.getElementById("diary-content") != null) {
     });
 }
 
-function diaryContentChange() {
-    window.addEventListener("beforeunload", function (event) {
-        event.preventDefault();
-        event.returnValue = "";
-    });
-}
+// /**
+//  * 日記の変更あった時にページ遷移で警告だす←除外処理が手間なので一旦保留
+//  */
+// function diaryContentChange() {
+//     window.addEventListener("beforeunload", function (event) {
+//         event.preventDefault();
+//         event.returnValue = "";
+//     });
+// }
+// /**提出フォームの時は上のものを除外する */
+// let submitButton = document.getElementsByTagName("button");
+// $("input[type=submit]").on("click", function () {
+//     $(window).off("beforeunload");
+// });
 
+/*
+    送信時のボタンをかっこよくする
+    https://codepen.io/nourabusoud/pen/ypZzMM
+
+    Copyright (c) 2022 by Nour Saud (https://codepen.io/nourabusoud/pen/ypZzMM)
+    Released under the MIT license
+    http://opensource.org/licenses/mit-license.php
+*/
+if (document.getElementById("submitDiary") != null) {
+    let submitDiaryAnimation = function (e) {
+        e.preventDefault;
+        e.target.classList.remove("animate");
+
+        e.target.classList.add("animate");
+        setTimeout(function () {
+            e.target.classList.remove("animate");
+        }, 400);
+    };
+
+    let submitDiaryButton = document.getElementById("submitDiary");
+
+    submitDiaryButton.addEventListener("click", submitDiaryAnimation, false);
+}
 //ヘッダー時計用桁数調整
 // function set2fig(num) {
 //     // 桁数が1桁だったら先頭に0を加えて2桁に調整する

--- a/backend/resources/views/components/basis/headMeta.blade.php
+++ b/backend/resources/views/components/basis/headMeta.blade.php
@@ -14,7 +14,7 @@
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"> --}}
 {{-- CSS読み込み --}}
 <link href="{{ asset('css/app.css') }}" rel="stylesheet">
-<link rel="stylesheet" href="{{ asset('css/kadodeMain.css') }}?ver=20.3">
+<link rel="stylesheet" href="{{ asset('css/kadodeMain.css') }}?ver=21.3">
 {{-- タイムライン用 --}}
 <link href="https://unpkg.com/vis-timeline@latest/styles/vis-timeline-graph2d.min.css" rel="stylesheet"
     type="text/css" />

--- a/backend/resources/views/components/basis/roadJS.blade.php
+++ b/backend/resources/views/components/basis/roadJS.blade.php
@@ -1,1 +1,1 @@
-<script type="text/javascript" src="{{ asset('js/kadodeMain.js') }}?ver=20.2"></script>
+<script type="text/javascript" src="{{ asset('js/kadodeMain.js') }}?ver=21.3"></script>

--- a/backend/resources/views/components/buttons/editDiaryButton.blade.php
+++ b/backend/resources/views/components/buttons/editDiaryButton.blade.php
@@ -1,3 +1,4 @@
 <div class="submit-button">
-    <a class="flex items-center justify-center flex-row text-main-color"href="{{url('/edit')}}/{{$edit_uuid}}"><span class="material-icons">edit</span><span class="kiwi-maru">編集</span></a>
+    <a class="flex items-center justify-center flex-row text-main-color" href="{{url('/edit')}}/{{$edit_uuid}}"><span
+            class="material-icons">sticky_note_2</span><span class="kiwi-maru">閲覧と閲覧</span></a>
 </div>

--- a/backend/resources/views/components/diary/submitForm.blade.php
+++ b/backend/resources/views/components/diary/submitForm.blade.php
@@ -40,7 +40,7 @@
 
 
         <textarea placeholder="本文(20000字以内)" class="sm:p-4 w-full diary-content-edit  " type="text" name="content"
-            autocomplete="off" id="diary-content"
+            autocomplete="off" id="diary-content" oninput="diaryContentChange()"
             onkeydown="if((event.ctrlKey || event.metaKey)&&event.keyCode==13){document.getElementById('submitDiary').click();return false};">{{$original_content}}</textarea>
 
         <input style="height:2em" type="submit" class="kiwi-maru" id="submitDiary" value="日記を書き込む">

--- a/backend/resources/views/components/diary/submitForm.blade.php
+++ b/backend/resources/views/components/diary/submitForm.blade.php
@@ -42,8 +42,9 @@
         <textarea placeholder="本文(20000字以内)" class="sm:p-4 w-full diary-content-edit  " type="text" name="content"
             autocomplete="off" id="diary-content" oninput="diaryContentChange()"
             onkeydown="if((event.ctrlKey || event.metaKey)&&event.keyCode==13){document.getElementById('submitDiary').click();return false};">{{$original_content}}</textarea>
-
-        <input style="height:2em" type="submit" class="kiwi-maru" id="submitDiary" value="日記を書き込む">
+        <button type="submit" style="height:2em" class="kiwi-maru submitDiaryButton" id="submitDiary">
+            日記を書き込む
+        </button>
     </form>
 
 </div>

--- a/backend/resources/views/components/statistics/char/charLengthRank.blade.php
+++ b/backend/resources/views/components/statistics/char/charLengthRank.blade.php
@@ -16,7 +16,7 @@
 
             <p class="kiwi-maru flex items-center"><span class="material-icons pr-2" style="font-size:0.9em;">
                     schedule
-                </span><span>{{$diary->date}}</span></p>
+                </span><span>{{$diary->date->format("Y年n月j日")}}</span></p>
             <h3 class="kiwi-maru text-3xl"><a href="{{url("edit/".$diary->uuid)}}">「{{$diary->title==""?"タイトルなし":$diary->title }}」</a></h3>
         </div>
     </div>

--- a/backend/resources/views/diary/archive/monthArchive.blade.php
+++ b/backend/resources/views/diary/archive/monthArchive.blade.php
@@ -65,7 +65,7 @@
         {{$diary->content}}
         @endslot
         @slot("date")
-        {{$diary->date}}
+        {{$diary->date->format("Y年n月j日")}}
         @endslot
         <!--統計部分の処理ここから-->
         @if($diary->is_latest_statistic)

--- a/backend/resources/views/diary/archive/yearArchive.blade.php
+++ b/backend/resources/views/diary/archive/yearArchive.blade.php
@@ -63,7 +63,7 @@
         {{$diary->content}}
         @endslot
         @slot("date")
-        {{$diary->date}}
+        {{$diary->date->format("Y年n月j日")}}
         @endslot
         <!--統計部分の処理ここから-->
         @if($diary->is_latest_statistic)

--- a/backend/resources/views/diary/edit.blade.php
+++ b/backend/resources/views/diary/edit.blade.php
@@ -80,6 +80,9 @@
     <div class="tab_content" id="viewDiaryContent">
         @if($diary->statistic_progress==100)
         @if($diary->is_latest_statistic==true)
+        @php
+        var_dump($contentWithNlp);
+        @endphp
         <p class="kiwi-maru diaryContentWrapper">{{$diary->content}}</p>
         @else
         <h3 class="kiwi-maru text-sm text-status-poor text-center my-6 mx-2">統計情報が最新でないため、<br

--- a/backend/resources/views/diary/edit.blade.php
+++ b/backend/resources/views/diary/edit.blade.php
@@ -80,10 +80,10 @@
     <div class="tab_content" id="viewDiaryContent">
         @if($diary->statistic_progress==100)
         @if($diary->is_latest_statistic==true)
-        @php
-        var_dump($contentWithNlp);
-        @endphp
-        <p class="kiwi-maru diaryContentWrapper">{{$diary->content}}</p>
+        <p class="kiwi-maru diaryContentWrapper">
+            @foreach($contentWithNlp as $word)<span class="" style="color:{{$word['color']}}"
+                title="{{$word['xPOSTag']}}">{{$word['form']}}</span>@endforeach
+        </p>
         @else
         <h3 class="kiwi-maru text-sm text-status-poor text-center my-6 mx-2">統計情報が最新でないため、<br
                 class="md:hidden">ハイライトはありません</h3>

--- a/backend/resources/views/diary/edit.blade.php
+++ b/backend/resources/views/diary/edit.blade.php
@@ -1,18 +1,17 @@
 @extends("layouts.main")
-@section("title","編集&閲覧")
+@section("title", $diary->date->format("Y年n月j日")."の日記")
 
 @section('header')
 @parent
 @endsection
 @section('content')
-<div class="board-main">
-
-    <div class="diary-main">
+<div class="board-main  kiwi-maru ">
+    <div class="dateWrapper">
         <nav class="md:order-1 ">
             @isset($next)
             <p class="md:mr-12 md:mt-12 p-2 text-xl borer-2 border-border-main-color kiwi-maru"><a
-                    style="vertical-align: middle;" href="{{url('/edit')}}/{{$next->uuid}}"><span
-                        class="material-icons">arrow_back</span> {{$next->date}}</a></p>
+                    style="vertical-align: middle;" href="{{url('/edit/'.$next->uuid)}}"><span
+                        class="material-icons">arrow_back</span> {{$next->date->format("Y年n月j日")}}</a></p>
             @else
             <p class="md:mr-12 md:mt-12 p-2 text-xl borer-2 border-border-main-color kiwi-maru"><span
                     class="material-icons ">arrow_back</span><span class="material-icons">remove_circle_outline</span>
@@ -23,173 +22,218 @@
         <nav class="order-2 md:order-3">
             @isset($previous)
             <p class="md:ml-12 md:mt-12 p-2 text-xl borer-2 border-border-main-color kiwi-maru"><a
-                    style="vertical-align: middle;" href="{{url('/edit')}}/{{$previous->uuid}}"> {{$previous->date}}
-                    <span class="material-icons">arrow_forward</span></a></p>
+                    style="vertical-align: middle;" href="{{url('/edit/'.$previous->uuid)}}">
+                    {{$previous->date->format("Y年n月j日")}}<span class="material-icons">arrow_forward</span></a></p>
             @else
             <p class="md:mr-12 md:mt-12 p-2 text-xl borer-2 border-border-main-color kiwi-maru">日記なし <span
                     class="material-icons">remove_circle_outline</span><span class="material-icons">arrow_forward</span>
             </p>
             @endisset
         </nav>
-        <div class="order-3 md:order-2 ">
-            @component('components.diary.submitForm')
-            @slot("db_method")
-            update
-            @endslot
-            @slot("original_uuid")
-            {{$diary->uuid}}
-            @endslot
-            @slot("original_date")
-            {{$diary->date}}
-            @endslot
-            @slot("original_title")
-            {{$diary->title}}
-            @endslot
-            @slot("original_content")
-            {{$diary->content}}
-            @endslot
-            @endcomponent
-        </div>
+        <nav class="order-3 md:order-2 ">
+            <h1 class="text-center mt-6 mb-4 mx-4 text-4xl drop-shadow-3xl">
+                @empty($diary->title)
+                <span class='text-gray-600'>タイトルなし</span>
+                @else
+                「{{$diary->title}}」
+                @endempty
+            </h1>
+            <h2 class="text-center mt-8 mb-2 mx-4 text-xl">
+                {{$diary->date->format('Y年n月j日')}}
+            </h2>
+        </nav>
     </div>
-
-    @component('components.diary.breadcrumbDate')
-    @slot("date")
-    {{$diary->date}}
-    @endslot
-    @endcomponent
-    @if($diary->is_latest_statistic==true)
-    <div class="my-4   md:mx-auto">
-        @empty($resembleDiaries)
-        <h3 class="text-center text-sm my-20 kiwi-maru">関連日記は見つかりませんでした。</h3>
-        @else
-        <h2 class="kiwi-maru text-3xl text-center mt-4 mb-4"><span class="material-icons">groups</span>関連日記</h2>
-        <p class="kiwi-maru text-sm text-center mt-4 mb-4 mx-2">※この機能はベータ版です。<br class="md:hidden">日記内に登場する人物から<br
-                class="md:hidden">関連付けしています。
-        </p>
-        <div class="flex justify-center items-center flex-wrap">
-            @foreach($resembleDiaries as $resembleDiary )
-            @component('components.diary.diaryFrame')
-            @slot("uuid")
-            {{$resembleDiary->uuid}}
-            @endslot
-            @slot("title")
-            {{$resembleDiary->title}}
-            @endslot
-            @slot("content")
-            {{$resembleDiary->content}}
-            @endslot
-            @slot("date")
-            {{$resembleDiary->date}}
-            @endslot
-            <!--統計部分の処理ここから-->
-            @if($resembleDiary->is_latest_statistic)
-            @slot("is_latest_statistic")
-            true
-            @endslot
-            @php
-            $emotions=$resembleDiary->emotions;
-            if($emotions>=0.5){
-            $emotions_icon="arrow_upward";
-            }else{
-            $emotions_icon="arrow_downward";
-            }
-            @endphp
-            @slot("emotions")
-            {{$emotions_icon}}
-            @endslot
-            @php
-            $words=$resembleDiary->important_words;
-            @endphp
-            @slot("important_words")
-            @if(count($words)>=1)
-            {{$words[0]['name']}}
-            @else
-            false
-            @endif
-            @endslot
-            @php
-            $people=$resembleDiary->special_people;
-            @endphp
-            @slot("special_people")
-            @if(count($people)>=1)
-            {{$people[0]['name']}}
-            @else
-            false
-            @endif
-            @endslot
-            @endif
-            <!--統計部分の処理ここまで-->
-            @endcomponent
-            @endforeach
+    <input id="editDiary" type="radio" name="tab_item">
+    <label class="tab_item" for="editDiary"><span class="material-icons">edit</span>編集</label>
+    <input id="viewDiary" type="radio" name="tab_item" checked>
+    <label class="tab_item" for="viewDiary"><span class="material-icons">library_books</span>閲覧</label>
+    <input id="viewStatistic" type="radio" name="tab_item">
+    <label class="tab_item" for="viewStatistic"><span class="material-icons">analytics</span>統計</label>
+    <div class="tab_content" id="editDiaryContent">
+        <div class="diary-main">
+            <div class="order-3 md:order-2 ">
+                @component('components.diary.submitForm')
+                @slot("db_method")
+                update
+                @endslot
+                @slot("original_uuid")
+                {{$diary->uuid}}
+                @endslot
+                @slot("original_date")
+                {{$diary->date->format("Y-m-d")}}
+                @endslot
+                @slot("original_title")
+                {{$diary->title}}
+                @endslot
+                @slot("original_content")
+                {{$diary->content}}
+                @endslot
+                @endcomponent
+            </div>
         </div>
+        @component('components.buttons.editorDiaryButton')
+        @slot("delete_uuid")
+        {{$diary->uuid}}
+        @endslot
+        @endcomponent
     </div>
-    @endempty
-    @else
-    {{-- <h3 class="text-center text-sm my-20 kiwi-maru">統計情報が最新でないため、関連日記も表示していません。</h3> --}}
-    @endif
-
-
-    <div class="my-12  border button-border-main-color md:w-2/3 md:mx-auto">
-        <h2 class="kiwi-maru text-3xl text-center mt-4"><span class="material-icons">science</span>解析情報</h2>
+    <div class="tab_content" id="viewDiaryContent">
         @if($diary->statistic_progress==100)
         @if($diary->is_latest_statistic==true)
-        <p class="text-right md:pr-12 px-2 text-sm mt-2 kiwi-maru">統計作成時刻: {{$diary->updated_statistic_at}}</p>
-        <div class="flex flex-wrap mx-4 md:mx-8">
-            <div class="w-full md:w-1/2">
-                @php
-                $emotions=$diary->emotions;
-                if($emotions>=0.5){
-                $emotions_chr="ポジティブ";
-                }else{
-                $emotions_chr="ネガティブ";
-                }
-
-                @endphp
-                @component('components.statistics.char.emotionsChar')
-                @slot("emotions_chr")
-                {{$emotions_chr}}
-                @endslot
-                @slot("emotions_num")
-                {{$emotions}}
-                @endslot
-                @endcomponent
-            </div>
-            {{-- <div class="w-full md:w-1/2">
-                @component('components.statistics.flavorChar')
-                @endcomponent
-            </div> --}}
-            <div class="w-full md:w-1/2">
-                @component('components.statistics.char.classificationsChar')
-                @slot("classification")
-                {{$diary->classification}}
-                @endslot
-                @endcomponent
-            </div>
-        </div>
-        @component('components.statistics.char.importantWordsChar',["important_words"=>$diary->important_words])
-
-        @endcomponent
-        {{-- @component('components.statistics.char.causeEffectChar')
-        @endcomponent --}}
-        @component('components.statistics.char.specialPeopleChar',["special_people"=>$diary->special_people])
-
-        @endcomponent
+        <p class="kiwi-maru diaryContentWrapper">{{$diary->content}}</p>
         @else
-        <h3 class="kiwi-maru text-2xl text-center my-6">統計情報が最新でないため表示していません</h3>
+        <h3 class="kiwi-maru text-sm text-status-poor text-center my-6 mx-2">統計情報が最新でないため、<br
+                class="md:hidden">ハイライトはありません</h3>
+        <p class="kiwi-maru diaryContentWrapper">{{$diary->content}}</p>
         @endif
         @elseif($diary->statistic_progress==0)
-        <h3 class="kiwi-maru text-2xl text-center my-6">統計情報が生成されていません</h3>
+        <h3 class="kiwi-maru text-sm text-status-poor text-center my-6 mx-2">統計情報が生成されていないため、<br
+                class="md:hidden">ハイライトはありません</h3>
+        <p class="kiwi-maru diaryContentWrapper">{{$diary->content}}</p>
         @else
-        <h3 class="kiwi-maru text-2xl text-center my-6">統計情報を生成中です</h3>
+        <h3 class="kiwi-maru text-sm text-status-poor text-center my-6 mx-2">統計情報を生成中のため、<br
+                class="md:hidden">ハイライトはありません</h3>
+        <p class="kiwi-maru diaryContentWrapper">{{$diary->content}}</p>
+        @endif
+
+    </div>
+    <div class="tab_content" id="viewStatisticContent">
+        <div class="mb-12  md:w-2/3 md:mx-auto">
+            <h2 class="kiwi-maru text-3xl text-center mt-4"><span class="material-icons">science</span>解析情報</h2>
+            @if($diary->statistic_progress==100)
+            @if($diary->is_latest_statistic==true)
+            <p class="text-right md:pr-12 px-2 text-sm mt-2 kiwi-maru">統計作成時刻: {{$diary->updated_statistic_at}}
+            </p>
+            <div class="flex flex-wrap mx-4 md:mx-8">
+                <div class="w-full md:w-1/2">
+                    @php
+                    $emotions=$diary->emotions;
+                    if($emotions>=0.5){
+                    $emotions_chr="ポジティブ";
+                    }else{
+                    $emotions_chr="ネガティブ";
+                    }
+
+                    @endphp
+                    @component('components.statistics.char.emotionsChar')
+                    @slot("emotions_chr")
+                    {{$emotions_chr}}
+                    @endslot
+                    @slot("emotions_num")
+                    {{$emotions}}
+                    @endslot
+                    @endcomponent
+                </div>
+                {{-- <div class="w-full md:w-1/2">
+                    @component('components.statistics.flavorChar')
+                    @endcomponent
+                </div> --}}
+                <div class="w-full md:w-1/2">
+                    @component('components.statistics.char.classificationsChar')
+                    @slot("classification")
+                    {{$diary->classification}}
+                    @endslot
+                    @endcomponent
+                </div>
+            </div>
+            @component('components.statistics.char.importantWordsChar',["important_words"=>$diary->important_words])
+
+            @endcomponent
+            {{-- @component('components.statistics.char.causeEffectChar')
+            @endcomponent --}}
+            @component('components.statistics.char.specialPeopleChar',["special_people"=>$diary->special_people])
+
+            @endcomponent
+            @else
+            <h3 class="kiwi-maru text-2xl text-center my-6">統計情報が最新でないため表示していません</h3>
+            @endif
+            @elseif($diary->statistic_progress==0)
+            <h3 class="kiwi-maru text-2xl text-center my-6">統計情報が生成されていません</h3>
+            @else
+            <h3 class="kiwi-maru text-2xl text-center my-6">統計情報を生成中です</h3>
+            @endif
+        </div>
+
+
+        @if($diary->is_latest_statistic==true)
+        <div class="mb-4   md:mx-auto">
+            @empty($resembleDiaries)
+            <h3 class="text-center text-sm my-20 kiwi-maru">関連日記は見つかりませんでした。</h3>
+            @else
+            <h2 class="kiwi-maru text-3xl text-center mt-4 mb-4"><span class="material-icons">groups</span>関連日記
+            </h2>
+            <p class="kiwi-maru text-sm text-center mt-4 mb-4 mx-2">※この機能はベータ版です。<br class="md:hidden">日記内に登場する人物から<br
+                    class="md:hidden">関連付けしています。
+            </p>
+            <div class="flex justify-center items-center flex-wrap">
+                @foreach($resembleDiaries as $resembleDiary )
+                @component('components.diary.diaryFrame')
+                @slot("uuid")
+                {{$resembleDiary->uuid}}
+                @endslot
+                @slot("title")
+                {{$resembleDiary->title}}
+                @endslot
+                @slot("content")
+                {{$resembleDiary->content}}
+                @endslot
+                @slot("date")
+                {{$resembleDiary->date->format("Y年n月j日")}}
+                @endslot
+                <!--統計部分の処理ここから-->
+                @if($resembleDiary->is_latest_statistic)
+                @slot("is_latest_statistic")
+                true
+                @endslot
+                @php
+                $emotions=$resembleDiary->emotions;
+                if($emotions>=0.5){
+                $emotions_icon="arrow_upward";
+                }else{
+                $emotions_icon="arrow_downward";
+                }
+                @endphp
+                @slot("emotions")
+                {{$emotions_icon}}
+                @endslot
+                @php
+                $words=$resembleDiary->important_words;
+                @endphp
+                @slot("important_words")
+                @if(count($words)>=1)
+                {{$words[0]['name']}}
+                @else
+                false
+                @endif
+                @endslot
+                @php
+                $people=$resembleDiary->special_people;
+                @endphp
+                @slot("special_people")
+                @if(count($people)>=1)
+                {{$people[0]['name']}}
+                @else
+                false
+                @endif
+                @endslot
+                @endif
+                <!--統計部分の処理ここまで-->
+                @endcomponent
+                @endforeach
+            </div>
+        </div>
+        @endempty
+        @else
+        {{-- <h3 class="text-center text-sm my-20 kiwi-maru">統計情報が最新でないため、関連日記も表示していません。</h3> --}}
         @endif
     </div>
-    @component('components.buttons.editorDiaryButton')
-    @slot("delete_uuid")
-    {{$diary->uuid}}
+</div>
+<div class="my-12">
+    @component('components.diary.breadcrumbDate')
+    @slot("date")
+    {{$diary->date->format("Y-n-j")}}
     @endslot
     @endcomponent
-
-
 </div>
 
 @endsection

--- a/backend/resources/views/diary/home.blade.php
+++ b/backend/resources/views/diary/home.blade.php
@@ -39,18 +39,21 @@
             @empty($yesterday)
             <h3 class="text-center text-3xl my-20 kiwi-maru">昨日の日記なし</h3>
             @else
-            @component('components.diary.latestDiaryContent')
-            @slot("uuid")
+            @component('components.diary.submitForm')
+            @slot("db_method")
+            update
+            @endslot
+            @slot("original_uuid")
             {{$yesterday->uuid}}
             @endslot
-            @slot("title")
+            @slot("original_date")
+            {{$yesterday->date->format("Y-m-d")}}
+            @endslot
+            @slot("original_title")
             {{$yesterday->title}}
             @endslot
-            @slot("content")
+            @slot("original_content")
             {{$yesterday->content}}
-            @endslot
-            @slot("date")
-            {{$yesterday->date->format("Y年n月j日")}}
             @endslot
             @endcomponent
             @endempty
@@ -75,22 +78,25 @@
             @endcomponent
 
             @else
-            <!--今日の日記あるときは、日記枠を表示-->
-            @component('components.diary.latestDiaryContent')
-            @slot("uuid")
+            <!--今日の日記あるときも、日記枠を表示-->
+            @component('components.diary.submitForm')
+            @slot("db_method")
+            update
+            @endslot
+            @slot("original_uuid")
             {{$today->uuid}}
             @endslot
-            @slot("title")
+            @slot("original_date")
+            {{$today->date->format("Y-m-d")}}
+            @endslot
+            @slot("original_title")
             {{$today->title}}
             @endslot
-            @slot("content")
+            @slot("original_content")
             {{$today->content}}
             @endslot
-            @slot("date")
-            {{$today->date->format("Y年n月j日")}}
-            @endslot
-
             @endcomponent
+
             @endempty
         </div>
 
@@ -112,7 +118,7 @@
         {{$diary->content}}
         @endslot
         @slot("date")
-        {{$diary->date->format("Y年n月j日")}}
+        {{$diary->date->format('Y年n月j日')}}
         @endslot
         <!--統計部分の処理ここから-->
         @if($diary->is_latest_statistic)

--- a/backend/resources/views/diary/home.blade.php
+++ b/backend/resources/views/diary/home.blade.php
@@ -50,7 +50,7 @@
             {{$yesterday->content}}
             @endslot
             @slot("date")
-            {{$yesterday->date}}
+            {{$yesterday->date->format("Y年n月j日")}}
             @endslot
             @endcomponent
             @endempty
@@ -87,7 +87,7 @@
             {{$today->content}}
             @endslot
             @slot("date")
-            {{$today->date}}
+            {{$today->date->format("Y年n月j日")}}
             @endslot
 
             @endcomponent
@@ -112,7 +112,7 @@
         {{$diary->content}}
         @endslot
         @slot("date")
-        {{$diary->date}}
+        {{$diary->date->format("Y年n月j日")}}
         @endslot
         <!--統計部分の処理ここから-->
         @if($diary->is_latest_statistic)

--- a/backend/resources/views/diary/search/searchResult.blade.php
+++ b/backend/resources/views/diary/search/searchResult.blade.php
@@ -68,7 +68,7 @@
         {!! $diary->content !!}
         @endslot
         @slot("date")
-        {{$diary->date}}
+        {{$diary->date->format("Y年n月j日")}}
         @endslot
         <!--統計部分の処理ここから-->
         @if($diary->is_latest_statistic)

--- a/backend/resources/views/diary/statistics/topStatistics.blade.php
+++ b/backend/resources/views/diary/statistics/topStatistics.blade.php
@@ -78,7 +78,8 @@
                     </form>
                     @endif
                     @endif
-                    <p class="text-lg my-2 ml-4 text-center kiwi-maru">前回データ更新日 : {{$statistics->updated_at}}</p>
+                    <p class="text-lg my-2 ml-4 text-center kiwi-maru">前回データ更新日 :
+                        {{$statistics->updated_at->format("Y年n月j日 H時y分s秒")}}</p>
         </div>
     </div>
     @if($statistics->statistic_progress==100)
@@ -93,7 +94,7 @@
                     $average=round($statistics->total_words/$statistics->total_diaries,2);
                     @endphp
                     <p class="text-xl ml-4">平均文字数 : {{$average}}字</p>
-                    <p class="text-xl ml-4">最古の日記 : {{$oldest_diary_date}}</p>
+                    <p class="text-xl ml-4">最古の日記 : {{$oldest_diary_date->format("Y年n月j日")}}</p>
                 </div>
             </div>
             <div class="md:w-1/2 my-12 md:mt-0">

--- a/backend/resources/views/livewire/editByLivewire.blade.php
+++ b/backend/resources/views/livewire/editByLivewire.blade.php
@@ -12,7 +12,7 @@
             @isset($next)
             <p class="md:mr-12 md:mt-12 p-2 text-xl borer-2 border-border-main-color kiwi-maru"><a
                     style="vertical-align: middle;" href="{{url('/edit')}}/{{$next->uuid}}"><span
-                        class="material-icons">arrow_back</span> {{$next->date}}</a></p>
+                        class="material-icons">arrow_back</span> {{$next->date->format("Y年n月j日")}}</a></p>
             @else
             <p class="md:mr-12 md:mt-12 p-2 text-xl borer-2 border-border-main-color kiwi-maru"><span
                     class="material-icons ">arrow_back</span><span class="material-icons">remove_circle_outline</span>
@@ -23,7 +23,7 @@
         <nav class="order-2 md:order-3">
             @isset($previous)
             <p class="md:ml-12 md:mt-12 p-2 text-xl borer-2 border-border-main-color kiwi-maru"><a
-                    style="vertical-align: middle;" href="{{url('/edit')}}/{{$previous->uuid}}"> {{$previous->date}}
+                    style="vertical-align: middle;" href="{{url('/edit')}}/{{$previous->uuid}}"> {{$previous->date->format("Y年n月j日")}}
                     <span class="material-icons">arrow_forward</span></a></p>
             @else
             <p class="md:mr-12 md:mt-12 p-2 text-xl borer-2 border-border-main-color kiwi-maru">日記なし <span
@@ -40,7 +40,7 @@
             {{$diary->uuid}}
             @endslot
             @slot("original_date")
-            {{$diary->date}}
+            {{$diary->date->format("Y年n月j日")}}
             @endslot
             @slot("original_title")
             {{$diary->title}}
@@ -54,7 +54,7 @@
 
     @component('components.diary.breadcrumbDate')
     @slot("date")
-    {{$diary->date}}
+    {{$diary->date->format("Y年n月j日")}}
     @endslot
     @endcomponent
     @if($diary->is_latest_statistic==true)
@@ -79,7 +79,7 @@
             {{$resembleDiary->content}}
             @endslot
             @slot("date")
-            {{$resembleDiary->date}}
+            {{$resembleDiary->date->format("Y年n月j日")}}
             @endslot
             <!--統計部分の処理ここから-->
             @if($resembleDiary->is_latest_statistic)

--- a/backend/tests/Unit/UseCases/Diary/ShapeContentWithNlpTest.php
+++ b/backend/tests/Unit/UseCases/Diary/ShapeContentWithNlpTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\UseCases\Diary;
+
+use App\Models\Diary;
+use App\UseCases\Diary\ShapeContentWithNlp;
+use Tests\TestCase;
+
+class ShapeContentWithNlpTest extends TestCase
+{
+    /** @test */
+    public function Diaryから配列になって帰ってくる()
+    {
+        return $this->markTestSkipped("現状の構成だとシーダーでNLPデータ作れないので、このテストは必ず失敗する。よってスキップ。未来に託します。");
+        $shapeContentWithNlp = new ShapeContentWithNlp();
+
+        /** @todo 依存関係消す */
+        $diary = Diary::where('statistic_progress', 100)->first();
+
+        $response = $shapeContentWithNlp->invoke($diary);
+        foreach ($response as $word) {
+            $this->assertArrayHasKey('lemma', $word);
+            $this->assertArrayHasKey('xPOSTag', $word);
+            $this->assertArrayHasKey('color', $word);
+        }
+    }
+}

--- a/backend/tests/Unit/UseCases/Diary/ShapeStatisticFromDiariesTest.php
+++ b/backend/tests/Unit/UseCases/Diary/ShapeStatisticFromDiariesTest.php
@@ -10,7 +10,6 @@ use Tests\TestCase;
 
 class ShapeStatisticFromDiariesTest extends TestCase
 {
-
     /** @test */
     public function コレクションを与えて、コレクションが帰ってくる()
     {


### PR DESCRIPTION
# やったこと
## トップページの直近の日記はトップで編集できるように
<img width="1062" alt="image" src="https://user-images.githubusercontent.com/63891531/169702177-7095f011-5e2c-4e27-aab3-b14ad8f977d4.png">

## 表示ページ刷新
<img width="1339" alt="image" src="https://user-images.githubusercontent.com/63891531/169702186-884118a3-1606-47b9-aabd-d619d5beac75.png">

## 表示部分ではホバーで品詞出るようにした
<img width="1463" alt="image" src="https://user-images.githubusercontent.com/63891531/169702122-efcc8ffa-8952-433b-a8b4-bf2b161eab8b.png">
→改善の余地あり

これ動作のためのusacaseのテストは保留  
→依存関係がエグすぎてむり。