### PR TITLE
fix ラベルの探索正規表現のミス修正

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,9 @@
 # 大枠
+💻frontend:
+  - backend/public/*
+  - backend/resources/*
 ⚙backend:
   - any: ["backend/*", "!backend/public/*", "!backend/resources/*"]
-💻frontend:
-  - any: ["backend/public/*", "backend/resources/*"]
 ✈ci:
   - .github/*
   - backend/env.ci

--- a/backend/resources/views/admin/packageAdmin.blade.php
+++ b/backend/resources/views/admin/packageAdmin.blade.php
@@ -345,9 +345,9 @@
                                     * 正規表現で該当するところにselectedをつける
                                     * mb_ereg_replaceはセパレータ不要
                                     */
-                                    $willSelect="<option value='".$NER->label_id."'>";
-                                        $selected="
-                                    <option selected value='".$NER->label_id."'>";
+                                    $willSelect='<option value="'.$NER->label_id.'">';
+                                        $selected='
+                                    <option selected value="'.$NER->label_id.'">';
 
                                         $NERLabelsInOptionTabFormatWithSelected=mb_ereg_replace($willSelect,$selected,$NERLabelsInOptionTabFormat);
                                         @endphp


### PR DESCRIPTION
バックエンドだけ変えて、フロントエンドを変えていなかったことが原因。

これはルールが複数箇所に点在していることが悪い。設計ミス。
