### PR TITLE
fix gitが自動で改行コードを変える際にフォントのバイナリを破壊していた

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,8 @@
 # Auto detect text files and perform LF normalization
 * text=auto eol=lf
+
+*.otf binary
+*.eot binary
+*.svg binary
+*.ttf binary
+*.woff binary


### PR DESCRIPTION
# やったこと

# 備考

# スクリーンショット(任意)
